### PR TITLE
feat(agent): add baseURL config for custom API endpoint

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -46,6 +46,7 @@ import { emitAgentEvent } from "./agent-events.js";
 // ============== 类型定义 ==============
 
 export interface AgentConfig {
+  /** Custom API endpoint (e.g. ZhipuAI BigModel). Fallback to ANTHROPIC_BASE_URL env if unset */
   baseURL?: string;
   /** Anthropic API Key */
   apiKey: string;
@@ -177,7 +178,10 @@ export class Agent {
   private enableHeartbeat: boolean;
 
   constructor(config: AgentConfig) {
-    this.client = new Anthropic({ baseURL: config.baseURL, apiKey: config.apiKey });
+    this.client = new Anthropic({
+      ...(config.baseURL ? { baseURL: config.baseURL } : {}),
+      apiKey: config.apiKey,
+    });
     this.model = config.model ?? "claude-sonnet-4-20250514";
     this.agentId = normalizeAgentId(config.agentId ?? "main");
     this.baseSystemPrompt = config.systemPrompt ?? DEFAULT_SYSTEM_PROMPT;

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -46,6 +46,7 @@ import { emitAgentEvent } from "./agent-events.js";
 // ============== 类型定义 ==============
 
 export interface AgentConfig {
+  baseURL?: string;
   /** Anthropic API Key */
   apiKey: string;
   /** 模型 ID */
@@ -176,7 +177,7 @@ export class Agent {
   private enableHeartbeat: boolean;
 
   constructor(config: AgentConfig) {
-    this.client = new Anthropic({ apiKey: config.apiKey });
+    this.client = new Anthropic({ baseURL: config.baseURL, apiKey: config.apiKey });
     this.model = config.model ?? "claude-sonnet-4-20250514";
     this.agentId = normalizeAgentId(config.agentId ?? "main");
     this.baseSystemPrompt = config.systemPrompt ?? DEFAULT_SYSTEM_PROMPT;


### PR DESCRIPTION
### Summary

  - Add optional `baseURL` parameter to `AgentConfig`, allowing users to configure a custom API endpoint for the Anthropic client
  - This enables using Anthropic SDK-compatible providers (e.g., https://docs.bigmodel.cn/cn/guide/develop/claude/introduction)

### Motivation

  The Anthropic SDK supports a baseURL option to redirect API calls to compatible third-party providers. By exposing this in `AgentConfig`, openclaw-mini becomes provider-agnostic with zero additional dependencies.

### Usage
```typescript
  const agent = new Agent({
    baseURL: "https://open.bigmodel.cn/api/anthropic",  // Custom API endpoint
    apiKey: "your-zhipuai-api-key",                      // Provider API key
    model: "glm-4.7",                                    // Provider model
    workspaceDir: process.cwd(),
  });
```
